### PR TITLE
Same config variables as cmd line arguments

### DIFF
--- a/charts/promlens/Chart.yaml
+++ b/charts/promlens/Chart.yaml
@@ -1,7 +1,9 @@
 apiVersion: v2
 name: promlens
-version: 0.2.2
+version: 0.3.0
 description: This Chart installs and configures PromLens
+home: https://promlens.com
+icon:	https://promlens.com/apple-touch-icon.png
 sources: ["https://github.com/ricardo-ch/helm-charts/tree/main/charts/promlens"]
 maintainers:
   - name: ricardo-ch

--- a/charts/promlens/Chart.yaml
+++ b/charts/promlens/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: promlens
-version: 0.3.0
+version: 1.0.0
 description: This Chart installs and configures PromLens
 home: https://promlens.com
 icon: https://promlens.com/apple-touch-icon.png

--- a/charts/promlens/Chart.yaml
+++ b/charts/promlens/Chart.yaml
@@ -3,7 +3,7 @@ name: promlens
 version: 0.3.0
 description: This Chart installs and configures PromLens
 home: https://promlens.com
-icon:	https://promlens.com/apple-touch-icon.png
+icon: https://promlens.com/apple-touch-icon.png
 sources: ["https://github.com/ricardo-ch/helm-charts/tree/main/charts/promlens"]
 maintainers:
   - name: ricardo-ch

--- a/charts/promlens/README.md
+++ b/charts/promlens/README.md
@@ -1,6 +1,6 @@
 # PromLens
 
-![Version: 0.2.2](https://img.shields.io/badge/Version-0.2.2-informational?style=flat-square) ![Release Status](https://github.com/ricardo-ch/helm-charts/workflows/Release%20Charts/badge.svg)
+![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![Release Status](https://github.com/ricardo-ch/helm-charts/workflows/Release%20Charts/badge.svg)
 
 This chart installs [PromLens](https://promlens.com/) from [PromLabs](https://promlabs.com/).
 
@@ -23,11 +23,18 @@ Simply add this Chart repository to Helm:
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| config.gcs_sa | string | `""` | Google Cloud Storage Account |
-| config.grafana_api_key | string | `""` | Grafana API Key, see https://grafana.com/docs/grafana/latest/http_api/auth/ |
-| config.grafana_url | string | `""` | Grafana URL |
-| config.license | string | `""` | PromLens License |
-| config.shared_links_bucket_name | string | `"promlens"` | Bucket Name in Storage Account |
+| config.grafana.api_token | string | `nil` | The auth token to pass to the Grafana API, see https://grafana.com/docs/grafana/latest/http_api/auth/ |
+| config.grafana.enabled | bool | `true` | Enable Grafana Integration |
+| config.grafana.url | string | `nil` | The URL of your Grafana installation, to enable the Grafana datasource selector. |
+| config.license_key | string | `""` | License key for PromLens |
+| config.log.format | string | `"logfmt"` | Output format of log messages. One of: [logfmt, json] |
+| config.log.level | string | `"info"` | Only log messages with the given severity or above. One of: [debug, info, warn, error] |
+| config.shared_links.gcs.bucket | string | `"promlens"` | Bucket Name in Storage Account |
+| config.shared_links.gcs.enabled | bool | `true` | Enable Link Sharing via Google Storage Bucket |
+| config.shared_links.gcs.storage_account | string | `nil` | Google Cloud Storage Account |
+| config.web.default_prometheus_url | string | `nil` | The default Prometheus URL to load PromLens with. |
+| config.web.external_url | string | `nil` | The URL under which PromLens is externally reachable (for example, if PromLens is served via a reverse proxy). Used for generating relative and absolute links back to PromLens itself. If the URL has a path portion, it will be used to prefix all HTTP endpoints served by PromLens. If omitted, relevant URL components will be derived automatically. |
+| config.web.listen_address | string | `":8080"` | The address to listen on for the web API. |
 | deployment.image | string | `"promlabs/promlens"` | PromLens Conatiner Image |
 | deployment.replicas | int | `1` | Number of replicas |
 | deployment.version | string | `"latest"` | PromLens Container Image Version |

--- a/charts/promlens/README.md
+++ b/charts/promlens/README.md
@@ -1,6 +1,6 @@
 # PromLens
 
-![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![Release Status](https://github.com/ricardo-ch/helm-charts/workflows/Release%20Charts/badge.svg)
+![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![Release Status](https://github.com/ricardo-ch/helm-charts/workflows/Release%20Charts/badge.svg)
 
 This chart installs [PromLens](https://promlens.com/) from [PromLabs](https://promlabs.com/).
 

--- a/charts/promlens/README.md
+++ b/charts/promlens/README.md
@@ -34,7 +34,7 @@ Simply add this Chart repository to Helm:
 | config.shared_links.gcs.storage_account | string | `nil` | Google Cloud Storage Account |
 | config.web.default_prometheus_url | string | `nil` | The default Prometheus URL to load PromLens with. |
 | config.web.external_url | string | `nil` | The URL under which PromLens is externally reachable (for example, if PromLens is served via a reverse proxy). Used for generating relative and absolute links back to PromLens itself. If the URL has a path portion, it will be used to prefix all HTTP endpoints served by PromLens. If omitted, relevant URL components will be derived automatically. |
-| config.web.listen_address | string | `":8080"` | The address to listen on for the web API. |
+| config.web.listen_address | int | `8080` | The address to listen on for the web API. |
 | deployment.image | string | `"promlabs/promlens"` | PromLens Conatiner Image |
 | deployment.replicas | int | `1` | Number of replicas |
 | deployment.version | string | `"latest"` | PromLens Container Image Version |

--- a/charts/promlens/templates/deployment.yaml
+++ b/charts/promlens/templates/deployment.yaml
@@ -21,19 +21,23 @@ spec:
       - name: promlens
         image: {{ .Values.deployment.image }}:{{ .Values.deployment.version }}
         args:
-          {{ if .Values.config.shared_links.gcs.enabled }}
-          - "--shared-links.gcs.bucket={{ .Values.config.shared_links_bucket_name }}"
-          {{ end }}
-          {{ if .Values.config.grafana.enabled }}
-          - "--grafana.url={{ .Values.config.grafana.url }}"
-          - "--grafana.api-token={{ .Values.config.grafana.api_token }}"
-          {{ end }}
-          - "--web.listen-address={{ .Values.config.web.listen_address }}"
-          - "--web.external-url={{ .Values.config.web.external_url }}"
-          - "--web.default-prometheus-url={{ .Values.config.web.default_prometheus_url }}"
-          - "--log.level={{ .Values.config.log.level }}"
-          - "--log.format={{ .Values.config.log.format }}"
-          - "--license.key={{ .Values.config.license_key }}"
+          {{- if .Values.config.shared_links.gcs.enabled }}
+          - --shared-links.gcs.bucket={{ .Values.config.shared_links.gcs.bucket }}
+          {{- end }}
+          {{- if .Values.config.grafana.enabled }}
+          - --grafana.url={{ .Values.config.grafana.url }}
+          - --grafana.api-token={{ .Values.config.grafana.api_token }}
+          {{- end }}
+          - --web.listen-address=":{{ .Values.config.web.listen_address }}"
+          {{- if .Values.config.web.external_url }}
+          - --web.external-url={{ .Values.config.web.external_url | quote }}
+          {{- end }}
+          {{- if .Values.config.web.default_prometheus_url }}
+          - --web.default-prometheus-url={{ .Values.config.web.default_prometheus_url | quote }}
+          {{- end }}
+          - --log.level={{ .Values.config.log.level }}
+          - --log.format={{ .Values.config.log.format }}
+          - --license.key={{ .Values.config.license_key }}
 
 {{ if .Values.config.shared_links.gcs.enabled }}
         env:

--- a/charts/promlens/templates/deployment.yaml
+++ b/charts/promlens/templates/deployment.yaml
@@ -21,12 +21,21 @@ spec:
       - name: promlens
         image: {{ .Values.deployment.image }}:{{ .Values.deployment.version }}
         args:
+          {{ if .Values.config.shared_links.gcs.enabled }}
           - "--shared-links.gcs.bucket={{ .Values.config.shared_links_bucket_name }}"
-          - "--grafana.url={{ .Values.config.grafana_url }}"
-          - "--grafana.api-token"
-          - {{ .Values.config.grafana_api_key | quote  }}
-          - "--license.key"
-          - {{ .Values.config.license | quote  }}
+          {{ end }}
+          {{ if .Values.config.grafana.enabled }}
+          - "--grafana.url={{ .Values.config.grafana.url }}"
+          - "--grafana.api-token={{ .Values.config.grafana.api_token }}"
+          {{ end }}
+          - "--web.listen-address={{ .Values.config.web.listen_address }}"
+          - "--web.external-url={{ .Values.config.web.external_url }}"
+          - "--web.default-prometheus-url={{ .Values.config.web.default_prometheus_url }}"
+          - "--log.level={{ .Values.config.log.level }}"
+          - "--log.format={{ .Values.config.log.format }}"
+          - "--license.key={{ .Values.config.license_key }}"
+
+{{ if .Values.config.shared_links.gcs.enabled }}
         env:
           - name: GOOGLE_APPLICATION_CREDENTIALS
             value: /var/secret-files/gcs-cred.json
@@ -38,3 +47,4 @@ spec:
           secret:
             defaultMode: 420
             secretName: promlens-secrets
+{{ end }}

--- a/charts/promlens/templates/secret.yaml
+++ b/charts/promlens/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.config.shared_links.gcs.enabled }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -9,4 +10,5 @@ metadata:
     heritage: {{ .Release.Service }}
 type: Opaque
 data:
-  gcs-cred.json: {{ .Values.config.gcs_sa | quote  }}
+  gcs-cred.json: {{ .Values.config.shared_links.storage_account | quote  }}
+{{ end}}

--- a/charts/promlens/templates/secret.yaml
+++ b/charts/promlens/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.config.shared_links.gcs.enabled }}
+{{- if .Values.config.shared_links.gcs.enabled }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -10,5 +10,5 @@ metadata:
     heritage: {{ .Release.Service }}
 type: Opaque
 data:
-  gcs-cred.json: {{ .Values.config.shared_links.storage_account | quote  }}
-{{ end}}
+  gcs-cred.json: {{ .Values.config.shared_links.gcs.storage_account | quote  }}
+{{- end}}

--- a/charts/promlens/templates/service.yaml
+++ b/charts/promlens/templates/service.yaml
@@ -10,8 +10,8 @@ metadata:
 spec:
   ports:
   - name: http
-    port: 8080
+    port: {{ .Values.config.web.listen_address }}
     protocol: TCP
-    targetPort: 8080
+    targetPort: {{ .Values.config.web.listen_address }}
   selector:
     app: {{ template "promlens.name" . }}

--- a/charts/promlens/values.yaml
+++ b/charts/promlens/values.yaml
@@ -29,7 +29,7 @@ config:
 
   web:
     # -- The address to listen on for the web API.
-    listen_address: ":8080"
+    listen_address: 8080
     # -- The URL under which PromLens is externally reachable (for example, if PromLens is served via a reverse proxy). Used for generating relative and absolute links back to PromLens itself. If the URL has a path portion, it will be used to prefix all HTTP endpoints served by PromLens. If omitted, relevant URL components will be derived automatically.
     external_url:
     # -- The default Prometheus URL to load PromLens with.

--- a/charts/promlens/values.yaml
+++ b/charts/promlens/values.yaml
@@ -2,17 +2,41 @@ deployment:
   # -- Number of replicas
   replicas: 1
   # -- PromLens Conatiner Image
-  image: promlabs/promlens
+  image: "promlabs/promlens"
   # -- PromLens Container Image Version
-  version: latest
+  version: "latest"
+
 config:
-  # -- PromLens License
-  license: ""
-  # -- Grafana URL
-  grafana_url: ""
-  # -- Grafana API Key, see https://grafana.com/docs/grafana/latest/http_api/auth/
-  grafana_api_key: ""
-  # -- Google Cloud Storage Account
-  gcs_sa: ""
-  # -- Bucket Name in Storage Account
-  shared_links_bucket_name: promlens
+  # -- License key for PromLens
+  license_key: ""
+
+  grafana:
+    # -- Enable Grafana Integration
+    enabled: true
+    # -- The URL of your Grafana installation, to enable the Grafana datasource selector.
+    url:
+    # -- The auth token to pass to the Grafana API, see https://grafana.com/docs/grafana/latest/http_api/auth/
+    api_token:
+
+  shared_links:
+    gcs:
+      # -- Enable Link Sharing via Google Storage Bucket
+      enabled: true
+      # -- Google Cloud Storage Account
+      storage_account:
+      # -- Bucket Name in Storage Account
+      bucket: "promlens"
+
+  web:
+    # -- The address to listen on for the web API.
+    listen_address: ":8080"
+    # -- The URL under which PromLens is externally reachable (for example, if PromLens is served via a reverse proxy). Used for generating relative and absolute links back to PromLens itself. If the URL has a path portion, it will be used to prefix all HTTP endpoints served by PromLens. If omitted, relevant URL components will be derived automatically.
+    external_url:
+    # -- The default Prometheus URL to load PromLens with.
+    default_prometheus_url:
+
+  log:
+    # -- Only log messages with the given severity or above. One of: [debug, info, warn, error]
+    level: "info"
+    # -- Output format of log messages. One of: [logfmt, json]
+    format: "logfmt"


### PR DESCRIPTION
Reworked the configuration variables to reflect their counterparts on the command line. 
we currently don't support all flags because we are not using all of them
see https://github.com/promlabs/promlens-public#flags