### PR TITLE
add kubernetes specific graceful shutdown

### DIFF
--- a/charts/imaginary/Chart.yaml
+++ b/charts/imaginary/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.2.4"
 description: Deploy imaginary to process pictures on the fly
 name: imaginary
-version: 0.1.0
+version: 0.1.1
 home: https://github.com/h2non/imaginary
 sources:
   - https://github.com/ricardo-ch/helm-charts/tree/main/charts/imaginary

--- a/charts/imaginary/README.md
+++ b/charts/imaginary/README.md
@@ -1,4 +1,4 @@
-# PromLens
+# Imaginary
 
 ![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![AppVersion: 1.2.4](https://img.shields.io/badge/AppVersion-1.2.4-informational?style=flat-square) ![Release Status](https://github.com/ricardo-ch/helm-charts/workflows/Release%20Charts/badge.svg) [![License](https://img.shields.io/github/license/ricardo-ch/helm-charts)](https://github.com/ricardo-ch/helm-charts/blob/main/LICENSE)
 

--- a/charts/imaginary/README.md
+++ b/charts/imaginary/README.md
@@ -28,7 +28,7 @@ Simply add this Chart repository to Helm:
 | additionalLabels | object | `{}` | append labels to both the deployment, pdb, hpa and the pods label list |
 | apikey | string | `""` | Define API key for authorization |
 | config | object | `{}` | Imaginary arguments. use the same hyphen separated synthax for the key. use strings for the value or you might get a bad formatting. |
-| gracefullShutdownDelaySeconds | int | `10` | estimated time to propagate the information the pod is not part of the service anymore |
+| gracefulShutdownDelaySeconds | int | `10` | estimated time to propagate the information the pod is not part of the service anymore |
 | hpa | object | `{"maxReplicas":2,"minReplicas":2}` | Horizontal pod autoscaling configuration |
 | httpPort | int | `8080` | Which port should Imaginary and its Kubernetes service listen |
 | image | string | `"h2non/imaginary:1.2.4"` | Docker image repository to pull it. |

--- a/charts/imaginary/README.md
+++ b/charts/imaginary/README.md
@@ -1,6 +1,6 @@
 # PromLens
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![AppVersion: 1.2.4](https://img.shields.io/badge/AppVersion-1.2.4-informational?style=flat-square) ![Release Status](https://github.com/ricardo-ch/helm-charts/workflows/Release%20Charts/badge.svg) [![License](https://img.shields.io/github/license/ricardo-ch/helm-charts)](https://github.com/ricardo-ch/helm-charts/blob/main/LICENSE)
+![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![AppVersion: 1.2.4](https://img.shields.io/badge/AppVersion-1.2.4-informational?style=flat-square) ![Release Status](https://github.com/ricardo-ch/helm-charts/workflows/Release%20Charts/badge.svg) [![License](https://img.shields.io/github/license/ricardo-ch/helm-charts)](https://github.com/ricardo-ch/helm-charts/blob/main/LICENSE)
 
 This chart installs [Imaginary](https://github.com/h2non/imaginary).
 
@@ -28,6 +28,7 @@ Simply add this Chart repository to Helm:
 | additionalLabels | object | `{}` | append labels to both the deployment, pdb, hpa and the pods label list |
 | apikey | string | `""` | Define API key for authorization |
 | config | object | `{}` | Imaginary arguments. use the same hyphen separated synthax for the key. use strings for the value or you might get a bad formatting. |
+| gracefullShutdownDelaySeconds | int | `10` | estimated time to propagate the information the pod is not part of the service anymore |
 | hpa | object | `{"maxReplicas":2,"minReplicas":2}` | Horizontal pod autoscaling configuration |
 | httpPort | int | `8080` | Which port should Imaginary and its Kubernetes service listen |
 | image | string | `"h2non/imaginary:1.2.4"` | Docker image repository to pull it. |

--- a/charts/imaginary/README.md.gotmpl
+++ b/charts/imaginary/README.md.gotmpl
@@ -1,4 +1,4 @@
-# PromLens
+# Imaginary
 
 {{ template "chart.deprecationWarning" . }}
 

--- a/charts/imaginary/templates/deployment.yaml
+++ b/charts/imaginary/templates/deployment.yaml
@@ -95,7 +95,7 @@ spec:
         lifecycle:
           preStop:
             exec:
-              command: ["sleep","{{ .Values.gracefullShutdownDelaySeconds }}"]
+              command: ["sleep","{{ .Values.gracefulShutdownDelaySeconds }}"]
       {{- if and .Values.tls.certificate .Values.tls.privateKey }}
       volumes:
       - name: certificates

--- a/charts/imaginary/templates/deployment.yaml
+++ b/charts/imaginary/templates/deployment.yaml
@@ -95,7 +95,7 @@ spec:
         lifecycle:
           preStop:
             exec:
-              command: ["sleep","{{ gracefullShutdownDelaySeconds }}"]
+              command: ["sleep","{{ .Values.gracefullShutdownDelaySeconds }}"]
       {{- if and .Values.tls.certificate .Values.tls.privateKey }}
       volumes:
       - name: certificates

--- a/charts/imaginary/templates/deployment.yaml
+++ b/charts/imaginary/templates/deployment.yaml
@@ -92,6 +92,10 @@ spec:
               value: {{ print .Values.apiKey | quote }}
             {{- end }}
           initialDelaySeconds: 10
+        lifecycle:
+          preStop:
+            exec:
+              command: ["sleep","{{ gracefullShutdownDelaySeconds }}"]
       {{- if and .Values.tls.certificate .Values.tls.privateKey }}
       volumes:
       - name: certificates

--- a/charts/imaginary/values.yaml
+++ b/charts/imaginary/values.yaml
@@ -47,12 +47,6 @@ tls:
   # -- Base64 encoded TLS certificate file
   certificate: ""
 
-# -- Horizontal pod autoscaling configuration
-hpa:
-  minReplicas: 2
-  maxReplicas: 2
-
-
 # -- Define API key for authorization
 apikey: ""
 
@@ -64,6 +58,15 @@ additionalLabels: {}
 additionalAnnotations: {}
   # sumologic.com/exclude: "true"
 
+# -- estimated time to propagate the information the pod is not part of the service anymore
+gracefullShutdownDelaySeconds:
+  10
+
 pdb:
   # -- minAvailable field from k8s pdb
   minAvailable: 50%
+
+# -- Horizontal pod autoscaling configuration
+hpa:
+  minReplicas: 2
+  maxReplicas: 2

--- a/charts/imaginary/values.yaml
+++ b/charts/imaginary/values.yaml
@@ -59,7 +59,7 @@ additionalAnnotations: {}
   # sumologic.com/exclude: "true"
 
 # -- estimated time to propagate the information the pod is not part of the service anymore
-gracefullShutdownDelaySeconds:
+gracefulShutdownDelaySeconds:
   10
 
 pdb:


### PR DESCRIPTION
when killing a pod, k8s does 2 things in parallel:
- send term signal to the pod
- remove the pod from the service list and propagate this information to all nodes

So there is a period the pod still receives requests after receiving the term signal.
It is a bit bothersome because it requires the caller to retry to avoid some unavailability and it adds noise to the logs and network.

After testing a bit, waiting for 10 seconds after receiving the term signal seems to solve this issue.



more infos:
https://medium.com/flant-com/kubernetes-graceful-shutdown-nginx-php-fpm-d5ab266963c2
https://blog.laputa.io/graceful-shutdown-in-kubernetes-85f1c8d586da
https://blog.gruntwork.io/gracefully-shutting-down-pods-in-a-kubernetes-cluster-328aecec90d
https://blog.gruntwork.io/delaying-shutdown-to-wait-for-pod-deletion-propagation-445f779a8304