### PR TITLE
Update to latest PromLens version

### DIFF
--- a/charts/promlens/Chart.yaml
+++ b/charts/promlens/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: promlens
-version: 1.0.4
-appVersion: 0.10.0
+version: 1.0.5
+appVersion: 0.11.0
 description: This Chart installs and configures PromLens from PromLabs.
 home: https://promlens.com
 icon: https://promlens.com/apple-touch-icon.png
@@ -18,7 +18,7 @@ keywords:
   - promql
 annotations:
   artifacthub.io/changes: |
-    - Adding Artifact-Hub Annotations
+    - Update Chart to use PromLens v0.11.0
   artifacthub.io/images: |
     - name: promlens
-      image: promlabs/promlens:v0.10.0
+      image: promlabs/promlens:v0.11.0

--- a/charts/promlens/README.md
+++ b/charts/promlens/README.md
@@ -1,6 +1,6 @@
 # PromLens
 
-![Version: 1.0.4](https://img.shields.io/badge/Version-1.0.4-informational?style=flat-square) ![AppVersion: 0.10.0](https://img.shields.io/badge/AppVersion-0.10.0-informational?style=flat-square) ![Release Status](https://github.com/ricardo-ch/helm-charts/workflows/Release%20Charts/badge.svg) [![License](https://img.shields.io/github/license/ricardo-ch/helm-charts)](https://github.com/ricardo-ch/helm-charts/blob/main/LICENSE)
+![Version: 1.0.5](https://img.shields.io/badge/Version-1.0.5-informational?style=flat-square) ![AppVersion: 0.11.0](https://img.shields.io/badge/AppVersion-0.11.0-informational?style=flat-square) ![Release Status](https://github.com/ricardo-ch/helm-charts/workflows/Release%20Charts/badge.svg) [![License](https://img.shields.io/github/license/ricardo-ch/helm-charts)](https://github.com/ricardo-ch/helm-charts/blob/main/LICENSE)
 
 This chart installs [PromLens](https://promlens.com/) from [PromLabs](https://promlabs.com/).
 
@@ -36,7 +36,7 @@ Simply add this Chart repository to Helm:
 | config.web.external_url | string | `nil` | The URL under which PromLens is externally reachable (for example, if PromLens is served via a reverse proxy). Used for generating relative and absolute links back to PromLens itself. If the URL has a path portion, it will be used to prefix all HTTP endpoints served by PromLens. If omitted, relevant URL components will be derived automatically. |
 | deployment.image | string | `"promlabs/promlens"` | PromLens Conatiner Image |
 | deployment.replicas | int | `1` | Number of replicas |
-| deployment.version | string | `"v0.10.0"` | PromLens Container Image Version |
+| deployment.version | string | `"v0.11.0"` | PromLens Container Image Version |
 
 ## Source Code
 

--- a/charts/promlens/values.yaml
+++ b/charts/promlens/values.yaml
@@ -4,7 +4,7 @@ deployment:
   # -- PromLens Conatiner Image
   image: "promlabs/promlens"
   # -- PromLens Container Image Version
-  version: "v0.10.0"
+  version: "v0.11.0"
 
 config:
   # -- License key for PromLens


### PR DESCRIPTION
Setting default Docker image to [PromLens v0.11.0](https://promlabs.com/blog/2020/12/15/showcasing-promlens-0.11.0)