### PR TITLE
Imaginary: support for istio

### DIFF
--- a/charts/imaginary/Chart.yaml
+++ b/charts/imaginary/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.2.4"
 description: Deploy imaginary to process pictures on the fly
 name: imaginary
-version: 0.1.2
+version: 0.1.3
 home: https://github.com/h2non/imaginary
 sources:
   - https://github.com/ricardo-ch/helm-charts/tree/main/charts/imaginary

--- a/charts/imaginary/Chart.yaml
+++ b/charts/imaginary/Chart.yaml
@@ -15,7 +15,7 @@ keywords:
   - h2non
 annotations:
   artifacthub.io/changes: |
-    - Fix Container Image Annotation
+    - Adding configuration for istio sidecar(injection and resources). Support istio 1.8+ annotations.
   artifacthub.io/images: |
     - name: imaginary
       image: h2non/imaginary:1.2.4

--- a/charts/imaginary/README.md
+++ b/charts/imaginary/README.md
@@ -34,8 +34,10 @@ Simply add this Chart repository to Helm:
 | image | string | `"h2non/imaginary:1.2.4"` | Docker image repository to pull it. |
 | imagePullPolicy | string | `"IfNotPresent"` | imagePullPolicy used by k8s |
 | istio.cpu | string | `"10m"` | istio sidecar cpu request |
+| istio.cpuLimit | string | `"10m"` | istio sidecar cpu request limit |
 | istio.inject | bool | `false` | istio sidecar configuration, enable injecting sidecar |
 | istio.memory | string | `"128Mi"` | istio sidecar memory request |
+| istio.memoryLimit | string | `"128Mi"` | istio sidecar memory limit |
 | livenessProbe.failureThreshold | int | `3` |  |
 | livenessProbe.periodSeconds | int | `10` |  |
 | livenessProbe.successThreshold | int | `1` |  |

--- a/charts/imaginary/README.md
+++ b/charts/imaginary/README.md
@@ -1,6 +1,6 @@
 # Imaginary
 
-![Version: 0.1.2](https://img.shields.io/badge/Version-0.1.2-informational?style=flat-square) ![AppVersion: 1.2.4](https://img.shields.io/badge/AppVersion-1.2.4-informational?style=flat-square) ![Release Status](https://github.com/ricardo-ch/helm-charts/workflows/Release%20Charts/badge.svg) [![License](https://img.shields.io/github/license/ricardo-ch/helm-charts)](https://github.com/ricardo-ch/helm-charts/blob/main/LICENSE)
+![Version: 0.1.3](https://img.shields.io/badge/Version-0.1.3-informational?style=flat-square) ![AppVersion: 1.2.4](https://img.shields.io/badge/AppVersion-1.2.4-informational?style=flat-square) ![Release Status](https://github.com/ricardo-ch/helm-charts/workflows/Release%20Charts/badge.svg) [![License](https://img.shields.io/github/license/ricardo-ch/helm-charts)](https://github.com/ricardo-ch/helm-charts/blob/main/LICENSE)
 
 This chart installs [Imaginary](https://github.com/h2non/imaginary).
 
@@ -33,6 +33,9 @@ Simply add this Chart repository to Helm:
 | httpPort | int | `8080` | Which port should Imaginary and its Kubernetes service listen |
 | image | string | `"h2non/imaginary:1.2.4"` | Docker image repository to pull it. |
 | imagePullPolicy | string | `"IfNotPresent"` | imagePullPolicy used by k8s |
+| istio.cpu | string | `"10m"` | istio sidecar cpu request |
+| istio.inject | bool | `false` | istio sidecar configuration, enable injecting sidecar |
+| istio.memory | string | `"128Mi"` | istio sidecar memory request |
 | livenessProbe.failureThreshold | int | `3` |  |
 | livenessProbe.periodSeconds | int | `10` |  |
 | livenessProbe.successThreshold | int | `1` |  |

--- a/charts/imaginary/templates/deployment.yaml
+++ b/charts/imaginary/templates/deployment.yaml
@@ -22,8 +22,13 @@ spec:
         {{- range $key, $value := .Values.additionalLabels }}
         {{ $key }}: {{ $value }}
         {{- end }}
+{{ if .Values.additionalAnnotations }}
       annotations:
 {{ toYaml .Values.additionalAnnotations | indent 8 }}
+        sidecar.istio.io/inject: {{ default false .Values.istio.on }}                                                                                                                                                                     │
+        sidecar.istio.io/proxyCPU: {{ default "10m" .Values.istio.cpu }}                                                                                                                                                        │
+        sidecar.istio.io/proxyMemory: {{ default "10Mi" .Values.istio.memory }}
+{{ end }}
     spec:
       {{- if .Values.nodeSelector }}
       nodeSelector:

--- a/charts/imaginary/templates/deployment.yaml
+++ b/charts/imaginary/templates/deployment.yaml
@@ -22,13 +22,14 @@ spec:
         {{- range $key, $value := .Values.additionalLabels }}
         {{ $key }}: {{ $value }}
         {{- end }}
-{{ if .Values.additionalAnnotations }}
       annotations:
-{{ toYaml .Values.additionalAnnotations | indent 8 }}
-        sidecar.istio.io/inject: {{ default false .Values.istio.on }}                                                                                                                                                                     │
-        sidecar.istio.io/proxyCPU: {{ default "10m" .Values.istio.cpu }}                                                                                                                                                        │
+{{- if .Values.istio.inject }}
+        sidecar.istio.io/inject: {{ quote .Values.istio.inject }}
+        sidecar.istio.io/proxyCPU: {{ default "10m" .Values.istio.cpu }}
         sidecar.istio.io/proxyMemory: {{ default "10Mi" .Values.istio.memory }}
-{{ end }}
+{{- end }}
+{{ toYaml .Values.additionalAnnotations | indent 8 }}
+
     spec:
       {{- if .Values.nodeSelector }}
       nodeSelector:

--- a/charts/imaginary/templates/deployment.yaml
+++ b/charts/imaginary/templates/deployment.yaml
@@ -25,11 +25,12 @@ spec:
       annotations:
 {{- if .Values.istio.inject }}
         sidecar.istio.io/inject: {{ quote .Values.istio.inject }}
-        sidecar.istio.io/proxyCPU: {{ default "10m" .Values.istio.cpu }}
-        sidecar.istio.io/proxyMemory: {{ default "10Mi" .Values.istio.memory }}
+        sidecar.istio.io/proxyCPU: {{ .Values.istio.cpu }}
+        sidecar.istio.io/proxyCPULimit: {{ .Values.istio.cpuLimit }}
+        sidecar.istio.io/proxyMemory: {{ .Values.istio.memory }}
+        sidecar.istio.io/proxyMemoryLimit: {{ .Values.istio.memoryLimit }}
 {{- end }}
 {{ toYaml .Values.additionalAnnotations | indent 8 }}
-
     spec:
       {{- if .Values.nodeSelector }}
       nodeSelector:

--- a/charts/imaginary/values.yaml
+++ b/charts/imaginary/values.yaml
@@ -63,8 +63,12 @@ istio:
   inject: false
   # -- istio sidecar memory request
   memory: 128Mi
+  # -- istio sidecar memory limit
+  memoryLimit: 128Mi
   # -- istio sidecar cpu request
   cpu: 10m
+  # -- istio sidecar cpu request limit
+  cpuLimit: 10m
 
 # -- estimated time to propagate the information the pod is not part of the service anymore
 gracefulShutdownDelaySeconds:

--- a/charts/imaginary/values.yaml
+++ b/charts/imaginary/values.yaml
@@ -57,8 +57,14 @@ additionalLabels: {}
 # -- append annotation to the pod annotation list
 additionalAnnotations: {}
   # sumologic.com/exclude: "true"
+
 istio:
-  on: false
+  # -- istio sidecar configuration, enable injecting sidecar
+  inject: false
+  # -- istio sidecar memory request
+  memory: 128Mi
+  # -- istio sidecar cpu request
+  cpu: 10m
 
 # -- estimated time to propagate the information the pod is not part of the service anymore
 gracefulShutdownDelaySeconds:

--- a/charts/imaginary/values.yaml
+++ b/charts/imaginary/values.yaml
@@ -57,6 +57,8 @@ additionalLabels: {}
 # -- append annotation to the pod annotation list
 additionalAnnotations: {}
   # sumologic.com/exclude: "true"
+istio:
+  on: false
 
 # -- estimated time to propagate the information the pod is not part of the service anymore
 gracefulShutdownDelaySeconds:


### PR DESCRIPTION
Introducing configuration options for adding imaginary into mesh:
- istio.inject - adding or not into mesh 
- istio.cpu - request cpu for sidecar
- istio.memory - request memory  for sidecar
- istio.cpuLimit - limit cpu for sidecar
- istio.memoryLimit - limit memory  for sidecar

Required annotations are added to the deployment only if istio.inject is set true. 



 