### PR TITLE
change default docker image

### DIFF
--- a/charts/bunnycdn-exporter/Chart.yaml
+++ b/charts/bunnycdn-exporter/Chart.yaml
@@ -1,11 +1,11 @@
 apiVersion: v2
 name: bunnycdn-exporter
-version: 1.0.0
-appVersion: 1.0.0
+version: 1.1.0
+appVersion: 0.2.3
 description: Prometheus exporter for BunnyCDN
 home: https://bunny.net/
 sources:
-  - https://github.com/permutive/bunnycdn_exporter
+  - https://github.com/ricardo-ch/bunnycdn_exporter
   - https://github.com/ricardo-ch/helm-charts/tree/main/charts/bunnycdn-exporter
 maintainers:
   - name: ricardo-ch
@@ -14,7 +14,7 @@ keywords:
   - bunnycdn
 annotations:
   artifacthub.io/changes: |
-    - First public release
+    - Change default image to ricardoag/bunnycdn_exporter which includes metric bugfixes, updated dependencies and doesn't run as root user.
   artifacthub.io/images: |
-    - name: bunnycdn-exporter
-      image: permutive/bunnycdn-exporter:0.1.0
+    - name: bunnycdn_exporter
+      image: ricardoag/bunnycdn_exporter:v0.2.3

--- a/charts/bunnycdn-exporter/README.md
+++ b/charts/bunnycdn-exporter/README.md
@@ -1,6 +1,6 @@
 # bunnycdn-exporter
 
-![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
+![Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-informational?style=flat-square) ![AppVersion: 0.2.3](https://img.shields.io/badge/AppVersion-0.2.3-informational?style=flat-square)
 
 Prometheus exporter for BunnyCDN
 
@@ -14,7 +14,7 @@ Prometheus exporter for BunnyCDN
 
 ## Source Code
 
-* <https://github.com/permutive/bunnycdn_exporter>
+* <https://github.com/ricardo-ch/bunnycdn_exporter>
 * <https://github.com/ricardo-ch/helm-charts/tree/main/charts/bunnycdn-exporter>
 
 ## Values
@@ -22,9 +22,9 @@ Prometheus exporter for BunnyCDN
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | api_key | string | `""` | The BunnyCDN API Key, see https://support.bunny.net/hc/en-us/articles/360012168840 |
-| deployment.image | string | `"permutive/bunnycdn-exporter"` | BunnyCDN Exporter Container Image |
+| deployment.image | string | `"ricardoag/bunnycdn_exporter"` | BunnyCDN Exporter Container Image |
 | deployment.pull_policy | string | `"IfNotPresent"` | Pull Policy |
-| deployment.version | string | `"0.1.0"` | BunnyCDN Exporter Image Version |
+| deployment.version | string | `"v0.2.3"` | BunnyCDN Exporter Image Version |
 | port | string | `"9584"` | Scrape port |
 | resources | object | `{"limits":{"memory":"20Mi"},"requests":{"cpu":"2m","memory":"20Mi"}}` | Kubernetes resource limits |
 | scrape | string | `"true"` | Scraping enabled? |

--- a/charts/bunnycdn-exporter/values.yaml
+++ b/charts/bunnycdn-exporter/values.yaml
@@ -1,8 +1,8 @@
 deployment:
   # -- BunnyCDN Exporter Container Image
-  image: "permutive/bunnycdn-exporter"
+  image: "ricardoag/bunnycdn_exporter"
   # -- BunnyCDN Exporter Image Version
-  version: "0.1.0"
+  version: "v0.2.3"
   # -- Pull Policy
   pull_policy: IfNotPresent
 


### PR DESCRIPTION
Change default image to [ricardoag/bunnycdn_exporter](https://hub.docker.com/r/ricardoag/bunnycdn_exporter) which includes metric bugfixes, updated dependencies and doesn't run as root user.