### PR TITLE
proxy server tls support

### DIFF
--- a/charts/kafka-proxy/Chart.yaml
+++ b/charts/kafka-proxy/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: kafka-proxy
-version: 0.1.1
+version: 0.1.2
 appVersion: 0.3.1
 description: Deploying the grepplabs kafka-proxy as a StatefulSet with a GKE LoadBalancer
 home: https://github.com/grepplabs/kafka-proxy
@@ -14,7 +14,7 @@ keywords:
   - kafka-proxy
 annotations:
   artifacthub.io/changes: |
-    - Support for NodePort and LoadBalancer services
+    - Proxy server TLS support
   artifacthub.io/images: |
     - name: kafka-proxy
       image: grepplabs/kafka-proxy:v0.3.1

--- a/charts/kafka-proxy/Chart.yaml
+++ b/charts/kafka-proxy/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: kafka-proxy
-version: 0.1.2
+version: 0.2.0
 appVersion: 0.3.1
 description: Deploying the grepplabs kafka-proxy as a StatefulSet with a GKE LoadBalancer
 home: https://github.com/grepplabs/kafka-proxy

--- a/charts/kafka-proxy/README.md
+++ b/charts/kafka-proxy/README.md
@@ -1,6 +1,6 @@
 # PromLens
 
-![Version: 0.1.2](https://img.shields.io/badge/Version-0.1.2-informational?style=flat-square) ![AppVersion: 0.3.1](https://img.shields.io/badge/AppVersion-0.3.1-informational?style=flat-square) ![Release Status](https://github.com/ricardo-ch/helm-charts/workflows/Release%20Charts/badge.svg) [![License](https://img.shields.io/github/license/ricardo-ch/helm-charts)](https://github.com/ricardo-ch/helm-charts/blob/main/LICENSE)
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![AppVersion: 0.3.1](https://img.shields.io/badge/AppVersion-0.3.1-informational?style=flat-square) ![Release Status](https://github.com/ricardo-ch/helm-charts/workflows/Release%20Charts/badge.svg) [![License](https://img.shields.io/github/license/ricardo-ch/helm-charts)](https://github.com/ricardo-ch/helm-charts/blob/main/LICENSE)
 
 This chart installs [kafka-proxy](https://github.com/grepplabs/kafka-proxy).
 

--- a/charts/kafka-proxy/README.md
+++ b/charts/kafka-proxy/README.md
@@ -1,6 +1,6 @@
 # PromLens
 
-![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![AppVersion: 0.3.1](https://img.shields.io/badge/AppVersion-0.3.1-informational?style=flat-square) ![Release Status](https://github.com/ricardo-ch/helm-charts/workflows/Release%20Charts/badge.svg) [![License](https://img.shields.io/github/license/ricardo-ch/helm-charts)](https://github.com/ricardo-ch/helm-charts/blob/main/LICENSE)
+![Version: 0.1.2](https://img.shields.io/badge/Version-0.1.2-informational?style=flat-square) ![AppVersion: 0.3.1](https://img.shields.io/badge/AppVersion-0.3.1-informational?style=flat-square) ![Release Status](https://github.com/ricardo-ch/helm-charts/workflows/Release%20Charts/badge.svg) [![License](https://img.shields.io/github/license/ricardo-ch/helm-charts)](https://github.com/ricardo-ch/helm-charts/blob/main/LICENSE)
 
 This chart installs [kafka-proxy](https://github.com/grepplabs/kafka-proxy).
 
@@ -28,6 +28,9 @@ This chart expects to run on GKE and makes use of [TCP/UDP load balancing](https
 | config.loadBalancerIP | string | `""` | Specifies an IP for the load balancers. If omitted, an ephemeral IP is assigned. |
 | config.loadBalancerSourceRanges | list | `["0.0.0.0/0"]` | Configures optional firewall rules in GKE and in the VPC to only allow certain source ranges. If you omit this field, your Service accepts traffic from any IP address (0.0.0.0/0). |
 | config.loadBalancerType | string | `"NodePort"` | Service Type, supported: LoadBalancer, NodePort |
+| config.proxyClientSaslEnabled | bool | `false` | SASL enabled on the proxy client. |
+| config.proxyClientTlsEnabled | bool | `true` | TLS enabled on the proxy client. |
+| config.proxyServerTlsEnabled | bool | `false` | TLS enabled on the proxy server. Requires a certificate deployed in a secret called 'kafka-proxy-cert' containing the certificate and key. |
 | image | string | `"grepplabs/kafka-proxy"` | Kafka-proxy Container Image |
 | nodeSelector | object | `{}` | A node selector label |
 | podAnnotations | object | `{"prometheus.io/port":"9399","prometheus.io/scrape":"true"}` | Set a pod annotations |

--- a/charts/kafka-proxy/templates/secret.yaml
+++ b/charts/kafka-proxy/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.config.proxyClientSaslEnabled }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -10,3 +11,4 @@ metadata:
 type: Opaque
 data:
   jaas.config: {{ .Values.config.kafkaClient.jaas | b64enc | quote }}
+{{- end }}

--- a/charts/kafka-proxy/templates/statefulset.yaml
+++ b/charts/kafka-proxy/templates/statefulset.yaml
@@ -62,8 +62,11 @@ spec:
                 apiVersion: v1
                 fieldPath: status.podIP
           volumeMounts:
+          {{- if .Values.config.proxyClientSaslEnabled }}
           - name: "proxy-config"
             mountPath: "/var/run/secret"
+            readOnly: true
+          {{- end }}
           {{- if .Values.config.proxyServerTlsEnabled }}
           - name: "tls-client-cert-file"
             mountPath: "/var/run/secret/kafka-client-certificate"

--- a/charts/kafka-proxy/templates/statefulset.yaml
+++ b/charts/kafka-proxy/templates/statefulset.yaml
@@ -35,16 +35,26 @@ spec:
             {{- range $index, $broker := .Values.config.kafkaClient.brokers }}
             - '--bootstrap-server-mapping={{ $broker }},0.0.0.0:{{ add 32400 $index}}{{ if ne $index 0}},{{ $.Values.config.loadBalancerIP | default "$(MY_POD_IP)" }}:{{ add 32400 $index }}{{ end }}'
             {{- end }}
+            {{- if .Values.config.proxyClientTlsEnabled }}
             - '--tls-enable'
+            {{- end }}
+            {{- if .Values.config.proxyServerTlsEnabled }}
+            - '--proxy-listener-tls-enable'
+            - '--proxy-listener-key-file=/var/run/secret/kafka-client-certificate/tls.key'
+            - '--proxy-listener-cert-file=/var/run/secret/kafka-client-certificate/tls.crt'
+            {{- end }}
+            {{- if .Values.config.proxyClientSaslEnabled }}
             - '--sasl-enable'
             - '--sasl-plugin-mechanism=PLAIN'
             - '--sasl-jaas-config-file=/var/run/secret/jaas.config'
+            {{- end }}
             - '--proxy-request-buffer-size=32768'
             - '--proxy-response-buffer-size=32768'
             - '--proxy-listener-read-buffer-size=32768'
             - '--proxy-listener-write-buffer-size=131072'
             - '--kafka-connection-read-buffer-size=131072'
             - '--kafka-connection-write-buffer-size=32768'
+
           env:
           - name: MY_POD_IP
             valueFrom:
@@ -54,6 +64,11 @@ spec:
           volumeMounts:
           - name: "proxy-config"
             mountPath: "/var/run/secret"
+          {{- if .Values.config.proxyServerTlsEnabled }}
+          - name: "tls-client-cert-file"
+            mountPath: "/var/run/secret/kafka-client-certificate"
+            readOnly: true
+          {{- end }}
           ports:
           - name: metrics
             containerPort: 9080
@@ -95,3 +110,8 @@ spec:
       - name: proxy-config
         secret:
           secretName: {{ include "kafka-proxy.fullname" . }}-config
+      {{- if .Values.config.proxyServerTlsEnabled }}
+      - name: tls-client-cert-file
+        secret:
+          secretName: kafka-proxy-cert
+      {{- end }}

--- a/charts/kafka-proxy/values.yaml
+++ b/charts/kafka-proxy/values.yaml
@@ -36,6 +36,12 @@ nodeSelector: {}
 affinity: {}
 
 config:
+  # -- TLS enabled on the proxy client.
+  proxyClientTlsEnabled: true
+  # -- TLS enabled on the proxy server. Requires a certificate deployed in a secret called 'kafka-proxy-cert' containing the certificate and key.
+  proxyServerTlsEnabled: false
+  # -- SASL enabled on the proxy client.
+  proxyClientSaslEnabled: false
   # -- Kafka client configuration
   kafkaClient:
     jaas: org.apache.kafka.common.security.plain.PlainLoginModule required username="username" password="password";


### PR DESCRIPTION
added support for tls support on the proxy server. 

requires a certificate deployed in the same k8s namespace, eg. with cert-manager.