### PR TITLE
postgresql-10.3.13 unavailable in bitnami helm repo

### DIFF
--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -4,7 +4,7 @@ dependencies:
 - condition: postgresql.enabled
   name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 10.3.13
+  version: 10.16.2
 description: Open Source Identity and Access Management For Modern Applications and Services
 home: https://www.keycloak.org/
 icon: https://www.keycloak.org/resources/images/keycloak_icon_512px.svg

--- a/charts/keycloak/README.md
+++ b/charts/keycloak/README.md
@@ -22,7 +22,7 @@ Open Source Identity and Access Management For Modern Applications and Services
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.bitnami.com/bitnami | postgresql | 10.3.13 |
+| https://charts.bitnami.com/bitnami | postgresql | 10.16.2 |
 
 ## Values
 


### PR DESCRIPTION
Release job fail because postgresql-10.3.13 is unavailable from bitnami helm repo

https://github.com/ricardo-ch/helm-charts/runs/7522887424?check_suite_focus=true


❯ helm pull  bitnami/postgresql --version 10.3.13
Error: chart "postgresql" matching 10.3.13 not found in bitnami index. (try 'helm repo update'): no chart version found for postgresql-10.3.13
