### PR TITLE
Add real volumeMount

### DIFF
--- a/charts/metrics-exporter/Chart.yaml
+++ b/charts/metrics-exporter/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: metrics-exporter
-version: 1.0.4
+version: 1.1.0
 appVersion: "0.5"
 description: This Chart installs and configures agnostic metrics exporter for
   sql servers
@@ -14,7 +14,7 @@ keywords:
   - sql_server
 annotations:
   artifacthub.io/changes: |
-    - Update Helm Docs to v1.11.0
+    - Add volume and volumeMount configuration
   artifacthub.io/images: |
     - name: free/sql_exporter
       image: githubfree/sql_exporter:0.5

--- a/charts/metrics-exporter/README.md
+++ b/charts/metrics-exporter/README.md
@@ -18,6 +18,8 @@ Simply add this Chart repository to Helm:
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | config | object | `{"sqlexporter":{}}` | Set a exporter configuration |
+| extraVolumeMounts | object | `{}` | Configure additional volumeMounts |
+| extraVolumes | object | `{}` | Configure additional volumes |
 | image.pullPolicy | string | `"IfNotPresent"` | Set an image pull policy |
 | image.repository | string | `"githubfree/sql_exporter"` | Set an exporter image |
 | image.tag | float | `0.5` | Set an image tag |

--- a/charts/metrics-exporter/README.md
+++ b/charts/metrics-exporter/README.md
@@ -1,6 +1,6 @@
 # metrics-exporter
 
-![Version: 1.0.4](https://img.shields.io/badge/Version-1.0.4-informational?style=flat-square) ![AppVersion: 0.5](https://img.shields.io/badge/AppVersion-0.5-informational?style=flat-square) ![Release Status](https://github.com/ricardo-ch/helm-charts/workflows/Release%20Charts/badge.svg) [![License](https://img.shields.io/github/license/ricardo-ch/helm-charts)](https://github.com/ricardo-ch/helm-charts/blob/main/LICENSE)
+![Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-informational?style=flat-square) ![AppVersion: 0.5](https://img.shields.io/badge/AppVersion-0.5-informational?style=flat-square) ![Release Status](https://github.com/ricardo-ch/helm-charts/workflows/Release%20Charts/badge.svg) [![License](https://img.shields.io/github/license/ricardo-ch/helm-charts)](https://github.com/ricardo-ch/helm-charts/blob/main/LICENSE)
 
 This chart installs [the DBMS agnostic metrics exporter](https://github.com/free/sql_exporter) based on SQL queries.
 
@@ -18,8 +18,8 @@ Simply add this Chart repository to Helm:
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | config | object | `{"sqlexporter":{}}` | Set a exporter configuration |
-| extraVolumeMounts | object | `{}` | Configure additional volumeMounts |
-| extraVolumes | object | `{}` | Configure additional volumes |
+| extraVolumeMounts | list | `[]` | Configure additional volumeMounts |
+| extraVolumes | list | `[]` | Configure additional volumes |
 | image.pullPolicy | string | `"IfNotPresent"` | Set an image pull policy |
 | image.repository | string | `"githubfree/sql_exporter"` | Set an exporter image |
 | image.tag | float | `0.5` | Set an image tag |

--- a/charts/metrics-exporter/templates/deployment.yaml
+++ b/charts/metrics-exporter/templates/deployment.yaml
@@ -31,7 +31,7 @@ spec:
             items:
               - key: "sql_exporter.yaml"
                 path: "sql_exporter.yaml"
-{{- with .Values.extraVolumeMounts }}
+{{- with .Values.extraVolumes }}
 {{ toYaml . | indent 8 }}
 {{- end }}
       containers:
@@ -52,6 +52,9 @@ spec:
             - name: config
               mountPath: /config
               readOnly: true
+{{- with .Values.extraVolumeMounts }}
+{{ toYaml . | indent 12 }}
+{{- end }}
 {{- with .Values.extraContainers }}
 {{ toYaml . | indent 8 }}
 {{- end }}

--- a/charts/metrics-exporter/values.yaml
+++ b/charts/metrics-exporter/values.yaml
@@ -5,7 +5,6 @@
 # -- Set number of pods
 replicaCount: 1
 
-
 image:
   # -- Set an exporter image
   repository: githubfree/sql_exporter
@@ -57,3 +56,8 @@ nodeSelector: {}
 # -- Set a exporter configuration
 config:
   sqlexporter: {}
+
+# -- Configure additional volumes
+extraVolumes: {}
+# -- Configure additional volumeMounts
+extraVolumeMounts: {}

--- a/charts/metrics-exporter/values.yaml
+++ b/charts/metrics-exporter/values.yaml
@@ -58,6 +58,6 @@ config:
   sqlexporter: {}
 
 # -- Configure additional volumes
-extraVolumes: {}
+extraVolumes: []
 # -- Configure additional volumeMounts
-extraVolumeMounts: {}
+extraVolumeMounts: []


### PR DESCRIPTION
Hi @robert-nemet, I found a little bug in your chart.
When I want to attach an extra volume to the pod, I need to do it in two places - in `Volumes` and then `containers/volumeMounts`.  As you can see, currently there is only one variable `Values.extraVolumeMounts` defined, and it placed wrong - to `Volumes` section. But there is nothing for `volumeMounts` yet.
In other words, I can attach the volume, but cannot mount it at the moment.
This PR resolves the issue.
Hope you can merge it asap. 
Thanks.