### PR TITLE
add subPath to config mount

### DIFF
--- a/charts/metrics-exporter/Chart.yaml
+++ b/charts/metrics-exporter/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: metrics-exporter
-version: 1.1.0
+version: 1.1.1
 appVersion: "0.5"
 description: This Chart installs and configures agnostic metrics exporter for
   sql servers

--- a/charts/metrics-exporter/Chart.yaml
+++ b/charts/metrics-exporter/Chart.yaml
@@ -15,6 +15,7 @@ keywords:
 annotations:
   artifacthub.io/changes: |
     - Add volume and volumeMount configuration
+    - Add subPath to config mount
   artifacthub.io/images: |
     - name: free/sql_exporter
       image: githubfree/sql_exporter:0.5

--- a/charts/metrics-exporter/README.md
+++ b/charts/metrics-exporter/README.md
@@ -1,6 +1,6 @@
 # metrics-exporter
 
-![Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-informational?style=flat-square) ![AppVersion: 0.5](https://img.shields.io/badge/AppVersion-0.5-informational?style=flat-square) ![Release Status](https://github.com/ricardo-ch/helm-charts/workflows/Release%20Charts/badge.svg) [![License](https://img.shields.io/github/license/ricardo-ch/helm-charts)](https://github.com/ricardo-ch/helm-charts/blob/main/LICENSE)
+![Version: 1.1.1](https://img.shields.io/badge/Version-1.1.1-informational?style=flat-square) ![AppVersion: 0.5](https://img.shields.io/badge/AppVersion-0.5-informational?style=flat-square) ![Release Status](https://github.com/ricardo-ch/helm-charts/workflows/Release%20Charts/badge.svg) [![License](https://img.shields.io/github/license/ricardo-ch/helm-charts)](https://github.com/ricardo-ch/helm-charts/blob/main/LICENSE)
 
 This chart installs [the DBMS agnostic metrics exporter](https://github.com/free/sql_exporter) based on SQL queries.
 

--- a/charts/metrics-exporter/templates/deployment.yaml
+++ b/charts/metrics-exporter/templates/deployment.yaml
@@ -50,7 +50,8 @@ spec:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
             - name: config
-              mountPath: /config
+              mountPath: /config/sql_exporter.yaml
+              subPath: sql_exporter.yaml
               readOnly: true
 {{- with .Values.extraVolumeMounts }}
 {{ toYaml . | indent 12 }}


### PR DESCRIPTION
Hi @bueti 
This PR fixes the issue with collector config mount. As you may know, SQL exporter need an extra collector config to work properly. It could be defined in ConfigMap and then mounted to `/config` directory aside of main config file. For example:
```
extraVolumeMounts:
  - name: collector
    mountPath: /config/sql.collector.yml
    subPath: sql.collector.yml
```
The problem is that current deployment config takes whole `/config` directory for mount a single file, so no other file could be mounted. Use of `subPath` solves this issue.